### PR TITLE
Update to latest reprocessing / bsb-native

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -30,6 +30,5 @@
   "warnings": {
     "error": "+101"
   },
-  "namespace": true,
   "refmt": 3
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -25,7 +25,7 @@
   "suffix": ".bs.js",
   "bs-dependencies": [
     // add your dependencies here. You'd usually install them normally through `npm install my-dependency`. If my-dependency has a bsconfig.json too, then everything will work seamlessly.
-    "Reprocessing"
+    "reprocessing"
   ],
   "warnings": {
     "error": "+101"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "bsansouci/bsb-native#3.2.0"
+    "bsb-native": "4.0.6"
   },
   "dependencies": {
-    "Reprocessing": "schmavery/reprocessing"
+    "reprocessing": "0.2.0"
   }
 }


### PR DESCRIPTION
There's a small bug with bsb-native which breaks reprocessing's hot reloading when using namespacing. So I turned it off here.